### PR TITLE
PoC: use htoml's parser

### DIFF
--- a/src/Text/Toml/Parser2.hs
+++ b/src/Text/Toml/Parser2.hs
@@ -21,7 +21,7 @@ tableToToml = Toml . Map.map nodeToNamable
 
 nodeToNamable :: Node -> TNamable
 nodeToNamable (VTable table) = TTable undefined $ tableToToml table
-nodeToNamable (VTArray tables) = TArray undefined $ map (nodeToNamable . VTable) tables
+nodeToNamable (VTArray tables) = TTableArray undefined $ map tableToToml tables
 nodeToNamable (VString s) = TString s
 nodeToNamable (VInteger i) = TInteger i
 nodeToNamable (VFloat d) = TDouble d

--- a/src/Text/Toml/Parser2.hs
+++ b/src/Text/Toml/Parser2.hs
@@ -20,14 +20,11 @@ tableToToml :: Table -> Toml
 tableToToml = Toml . Map.map nodeToNamable
 
 nodeToNamable :: Node -> TNamable
-nodeToNamable (NTValue value) = valueToNamable value
-nodeToNamable (NTable table) = TTable undefined $ tableToToml table
-nodeToNamable (NTArray tables) = TArray undefined $ map (TTable undefined . tableToToml) tables
-
-valueToNamable :: TValue -> TNamable
-valueToNamable (VString s) = TString s
-valueToNamable (VInteger i) = TInteger i
-valueToNamable (VFloat d) = TDouble d
-valueToNamable (VBoolean b) = TBoolean b
-valueToNamable (VDatetime t) = TDatetime t
-valueToNamable (VArray values) = TArray undefined $ map valueToNamable values
+nodeToNamable (VTable table) = TTable undefined $ tableToToml table
+nodeToNamable (VTArray tables) = TArray undefined $ map (nodeToNamable . VTable) tables
+nodeToNamable (VString s) = TString s
+nodeToNamable (VInteger i) = TInteger i
+nodeToNamable (VFloat d) = TDouble d
+nodeToNamable (VBoolean b) = TBoolean b
+nodeToNamable (VDatetime t) = TDatetime t
+nodeToNamable (VArray nodes) = TArray undefined $ map nodeToNamable nodes

--- a/src/Text/Toml/Parser2.hs
+++ b/src/Text/Toml/Parser2.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE PackageImports #-}
+module Text.Toml.Parser2
+    ( parseToml
+    ) where
+
+import "htoml" Text.Toml
+import "htoml" Text.Toml.Types
+
+import Text.Toml.Types.Toml
+
+import Data.Bifunctor (bimap)
+import Data.Text (Text)
+
+import qualified Data.HashMap.Strict as Map
+
+parseToml :: String -> Text -> Either String Toml
+parseToml src = bimap show tableToToml . parseTomlDoc src
+
+tableToToml :: Table -> Toml
+tableToToml = Toml . Map.map nodeToNamable
+
+nodeToNamable :: Node -> TNamable
+nodeToNamable (NTValue value) = valueToNamable value
+nodeToNamable (NTable table) = TTable undefined $ tableToToml table
+nodeToNamable (NTArray tables) = TArray undefined $ map (TTable undefined . tableToToml) tables
+
+valueToNamable :: TValue -> TNamable
+valueToNamable (VString s) = TString s
+valueToNamable (VInteger i) = TInteger i
+valueToNamable (VFloat d) = TDouble d
+valueToNamable (VBoolean b) = TBoolean b
+valueToNamable (VDatetime t) = TDatetime t
+valueToNamable (VArray values) = TArray undefined $ map valueToNamable values

--- a/src/Text/Toml/Types/Toml.hs
+++ b/src/Text/Toml/Types/Toml.hs
@@ -25,6 +25,7 @@ data Inlined = Inline | Outline | ImplicitOutline
 
 -- | Anything that can be named in a toml document.
 data TNamable = TTable       Inlined  Toml
+              | TTableArray  Inlined [Toml]
               | TArray       Inlined [TNamable]
               | TString               Text
               | TInteger              Int64

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,8 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- htoml-0.1.0.3
+- file-embed-0.0.10
+- htoml-0.2.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,8 @@ packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- htoml-0.1.0.3
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/test/Text/Toml/QuerySpec.hs
+++ b/test/Text/Toml/QuerySpec.hs
@@ -8,14 +8,14 @@ import Test.QuickCheck
 
 testDocument :: Toml
 testDocument = insert "A" (
-                  TTable Outline (insert "B" (TString "Hello World") (
+                  TTable undefined (insert "B" (TString "Hello World") (
                      insert "D" (TDouble 2.0) (
                      insert "X" (TInteger 42) (
                      insert "Y" (TBoolean True)
                      empty))
                   ))
                )
-               (insert "Arr" (TArray Inline [TDouble 3.14, TDouble 3]) empty)
+               (insert "Arr" (TArray undefined [TDouble 3.14, TDouble 3]) empty)
 
 main :: IO ()
 main = hspec spec

--- a/toml-parse.cabal
+++ b/toml-parse.cabal
@@ -21,6 +21,7 @@ library
                      , Text.Toml.Tokenizer
                      , Text.Toml.Combinators
                      , Text.Toml.Parser
+                     , Text.Toml.Parser2
                      , Text.Toml.Query
   build-depends:       base >= 4.7 && < 5.0
                      , text >= 1.2 && < 2.0
@@ -31,6 +32,7 @@ library
                      , bytestring >= 0.10.6 && < 1.0
                      , unordered-containers >= 0.2.5 && < 1.0
                      , parsec
+                     , htoml
   default-language:    Haskell2010
 
 executable toml-decoder

--- a/toml-parse.cabal
+++ b/toml-parse.cabal
@@ -32,7 +32,7 @@ library
                      , bytestring >= 0.10.6 && < 1.0
                      , unordered-containers >= 0.2.5 && < 1.0
                      , parsec
-                     , htoml
+                     , htoml >= 0.2.0
   default-language:    Haskell2010
 
 executable toml-decoder

--- a/toml-test/decoder.hs
+++ b/toml-test/decoder.hs
@@ -21,6 +21,7 @@ instance ToJSON Toml where
 
 instance ToJSON TNamable where
     toJSON (TTable _ t) = toJSON t
+    toJSON (TTableArray _ x) = toJSON x
     toJSON (TArray _ x) = object
         [ "type" .= ("array" :: String)
         , "value" .= toJSON x

--- a/toml-test/decoder.hs
+++ b/toml-test/decoder.hs
@@ -11,7 +11,7 @@ import System.Exit (exitFailure)
 
 import qualified Data.Text.IO as T
 
-import Text.Toml.Parser
+import Text.Toml.Parser2
 import Text.Toml.Types.Toml
 
 import qualified Data.HashMap.Strict as Map


### PR DESCRIPTION
This was an attempt to see if using the existing htoml's parser, but
translating to our own Toml type would:
1. Be easy to do
   
   I think yes, it took just a tiny bit of translation code. I had to use
   undefined for the Inline/Outline attribute because htoml doesn't have
   this concept. I think that means we could remove it from our type, if
   it's not needed for querying. If I'm wrong here, that could be the
   deal breaker.
2. Pass the BurntSushi decoder tests
   
   We're at 66/12 using this tiny spike. I haven't investigated yet as to
   what's breaking the 12 remaining, but would be happy to do so if this
   approach has merit.
3. Keep the benefits of improved queriability that prompted creating
   this package in the first place
   
   My assumption is that the querying code will work provided the
   interface of our Toml type is preserved. This spike didn't change it
   (modulo the Inline/Outline question) so I think this could be true.

If this approach is sound, my next step would be to drop all the
now-unnecessary modules and rebrand this as something like toml-query,
to avoid the import and module clashes, then investigate and address the
decoder test failures.

@clord what do you think?

Note: FWIW, if I update the `QuerySpec` to use `undefined` for the Inline/Outline field in the fixture document, it still passes.
