### PR TITLE
Run BurntSushi tests as HSpec cases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "toml-test"]
+	path = toml-test
+	url = https://github.com/BurntSushi/toml-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
+  # Include the BurntSushi decoder tests, these are allowed to fail because
+  # we're not fully compliant yet.
+  - env: BUILD=stack ARGS="--resolver lts-5" BURNT_SUSHI=1
+    compiler: ": #stack 7.10.3"
+    addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
@@ -53,6 +59,7 @@ matrix:
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head
   - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack ARGS="--resolver lts-5" BURNT_SUSHI=1
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it
@@ -77,6 +84,13 @@ install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 - if [ -f configure.ac ]; then autoreconf -i; fi
 - |
+  if [ "$BURNT_SUSHI" = "1" ]
+  then
+    git submodule update --init
+  else
+    rm -rf ./toml-test
+  fi
+- |
   case "$BUILD" in
     stack)
       stack --no-terminal --install-ghc $ARGS test --only-dependencies
@@ -87,6 +101,7 @@ install:
       cabal install --only-dependencies --enable-tests --enable-benchmarks --force-reinstalls --ghc-options=-O0 --reorder-goals --max-backjumps=-1 $CABALARGS
       ;;
   esac
+
 
 script:
 - |

--- a/README.md
+++ b/README.md
@@ -23,20 +23,12 @@ it was quite difficult to retrofit that for us.
 
 To run the [BurntSushi][] tests:
 
-1. Install `go`, export `$GOPATH`, and add `$GOPATH/bin` to `$PATH`
-1. Install `toml-test`:
+```console
+git submodule update --init
+```
 
-  ```
-  go get github.com/BurntSushi/toml-test
-  ```
-
-1. Run a test:
-
-  ```
-  stack install && toml-test toml-decoder bool
-  ```
-
-TODO: make these executables conditional (e.g. `-ftoml-test`)
+To clone the test files to the `toml-test` directory. These will now be picked
+up by the `BurntSushiSpec` file and run as part of `stack test`.
 
 [BurntSushi]: https://github.com/BurntSushi/toml-test
 [htoml]: https://github.com/cies/htoml

--- a/test/BurntSushiSpec.hs
+++ b/test/BurntSushiSpec.hs
@@ -1,0 +1,83 @@
+module BurntSushiSpec
+    ( main
+    , spec
+    ) where
+
+import SpecHelper ()
+import Test.Hspec
+import Text.Toml.Parser
+
+import Control.Monad (forM_)
+import Data.Aeson hiding (json)
+import Data.Aeson.Encode.Pretty
+import System.FilePath
+import System.FilePath.Glob (compile, globDir1)
+
+import qualified Data.ByteString.Lazy as BS
+import qualified Data.ByteString.Lazy.Char8 as C8
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+    let tests = "toml-test/tests"
+
+    validPaths <- runIO $ globDir1 (compile "*.toml") $ tests </> "valid"
+    invalidPaths <- runIO $ globDir1 (compile "*.toml") $ tests </> "invalid"
+
+    forM_ validPaths $ \fp -> do
+        toml <- runIO $ T.readFile fp
+        json <- runIO $ BS.readFile $ asJSON fp
+
+        it (makeRelative tests fp) $ do
+            let Right value = eitherDecode json :: Either String Value
+                eparsed = toJSON <$> parseToml fp toml
+
+            case eparsed of
+                Right parsed | parsed /= value ->
+                    expectationFailure $ unlines
+                        [ "Decoding mismatch"
+                        , "Input TOML:"
+                        , T.unpack toml
+                        , "", "Expected JSON:"
+                        , C8.unpack $ encodePretty value
+                        , "", "Actual JSON:"
+                        , C8.unpack $ encodePretty parsed
+                        ]
+
+                Left err ->
+                    expectationFailure $ unlines
+                        [ "Decoding error:"
+                        , "Input TOML:"
+                        , T.unpack toml
+                        , "", "Expected JSON:"
+                        , C8.unpack $ encodePretty value
+                        , "", "Error:"
+                        , err
+                        ]
+
+                _ -> return () -- success
+
+    forM_ invalidPaths $ \fp -> do
+        toml <- runIO $ T.readFile fp
+
+        it (makeRelative tests fp) $ do
+            let eparsed = toJSON <$> parseToml fp toml
+
+            case eparsed of
+                Right parsed ->
+                    expectationFailure $ unlines
+                        [ "Decoding success, expected failure"
+                        , "Input TOML:"
+                        , T.unpack toml
+                        , "", "Unexpected JSON:"
+                        , C8.unpack $ encodePretty parsed
+                        ]
+
+                Left _ -> return () -- success
+
+asJSON :: FilePath -> FilePath
+asJSON = (<.> "json") . dropExtension

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -1,20 +1,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Main (main) where
+module SpecHelper where
 
 import Data.Aeson
 import Data.Char (toLower)
 import Data.Time.Format
-import Data.Text.Lazy (toStrict)
-import Data.Text.Lazy.Encoding (decodeUtf8)
-import System.Exit (exitFailure)
-
-import qualified Data.Text.IO as T
-
-import Text.Toml.Parser
-import Text.Toml.Types.Toml
 
 import qualified Data.HashMap.Strict as Map
+
+import Text.Toml.Types.Toml
 
 instance ToJSON Toml where
     toJSON (Toml hm) = Object $ Map.map toJSON hm
@@ -48,9 +42,3 @@ instance ToJSON TNamable where
       where
         -- 1987-07-05T17:45:00Z
         format = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"
-
-main :: IO ()
-main = either
-    (\err -> putStrLn err >> exitFailure)
-    (T.putStrLn . toStrict . decodeUtf8 . encode)
-    . parseToml "<stdin>" =<< T.getContents

--- a/toml-parse.cabal
+++ b/toml-parse.cabal
@@ -33,17 +33,6 @@ library
                      , parsec
   default-language:    Haskell2010
 
-executable toml-decoder
-  hs-source-dirs:      toml-test
-  main-is:             decoder.hs
-  build-depends:       base
-                     , toml-parse
-                     , aeson
-                     , text
-                     , time
-                     , unordered-containers >= 0.2.5 && < 1.0
-  default-language:    Haskell2010
-
 test-suite toml-parse-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
@@ -51,9 +40,16 @@ test-suite toml-parse-test
   build-depends:       base
                      , hspec >= 2.1 && < 3.0
                      , toml-parse >= 0.1 && < 0.2
+                     , Glob
+                     , QuickCheck >= 2.8.1 && < 3.0
+                     , aeson
+                     , aeson-pretty
+                     , bytestring
+                     , filepath
                      , text >= 1.2 && < 2.0
                      , time >= 1.5 && < 2.0
-                     , QuickCheck >= 2.8.1 && < 3.0
+                     , transformers
+                     , unordered-containers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 


### PR DESCRIPTION
This allows for much more useful messaging, which incorporates the input
TOML, the expected JSON, etc. It's also arguably better to have it
incorporated in the main hspec suite.