### PR TITLE
Two fewer failures

### DIFF
--- a/src/Text/Toml/Combinators.hs
+++ b/src/Text/Toml/Combinators.hs
@@ -19,6 +19,7 @@ module Text.Toml.Combinators
     , float
     , date
     , localDate
+    , newline
     , satisfy
     , module Text.Parsec.Combinator
     ) where
@@ -119,6 +120,11 @@ module Text.Toml.Combinators
    bracketed :: Parser a -> Parser a
    bracketed = between lbracket rbracket
 
+   newline :: Parser ()
+   newline = satisfy it
+      where it (NewlineT _) = Just ()
+            it _ = Nothing
+
    -- | Satisfy the given predicate from the token stream.
    satisfy :: (Token -> Maybe a) -> Parser a
    satisfy = tokenPrim tokenString tokenPosition
@@ -141,6 +147,7 @@ module Text.Toml.Combinators
                         FloatT _ d _ -> "float \"" ++ show d ++ "\""
                         DateT _ d -> "date \"" ++ show d ++ "\""
                         LocalDateT _ d -> "date \"" ++ show d ++ "\""
+                        NewlineT _ -> "newline"
 
    -- | Update the source position to that of the next token in the stream
    tokenPosition :: SourcePos -> Token -> [Token] -> SourcePos

--- a/src/Text/Toml/Parser.hs
+++ b/src/Text/Toml/Parser.hs
@@ -7,13 +7,13 @@ import Text.Toml.Combinators
 import Text.Toml.Tokenizer
 import Text.Toml.Types.Toml
 
-import Control.Monad ((<=<))
+import Control.Monad ((<=<), void)
 import Data.Bifunctor (first)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Set as Set
 import Data.Time.LocalTime
-import Text.Parsec
+import Text.Parsec hiding (newline)
 
 -- Internal types for converting from parsed data to final Toml datatype
 type SectionKey = [Text]
@@ -35,7 +35,10 @@ mergeSection (ObjSection key lst) t = insertChildren key lst t
 mergeSection (ArraySection key lst) t = appendChildren key lst t
 
 parser :: Parser Toml
-parser = do (intro, rest) <- sections <* eof
+parser = do optional linebreaks
+            (intro, rest) <- sections
+            optional linebreaks
+            eof
             case firstDup (map fst intro) of
                Just x -> unexpected $ "duplicate " ++ (T.unpack x)
                Nothing ->
@@ -54,11 +57,14 @@ sectionKey :: Parser SectionKey
 sectionKey = (choice [identifier, quoted]) `sepBy1` period
 
 section :: Parser Section
-section = ArraySection <$> (try $ doubleBracketed sectionKey) <*> many assignment
-      <|> ObjSection   <$> (bracketed sectionKey)       <*> many assignment
+section = ArraySection <$> (try $ doubleBracketed sectionKey <* linebreaks) <*> many assignment
+      <|> ObjSection   <$> (bracketed sectionKey <* linebreaks) <*> many assignment
 
 assignment :: Parser (Text, TNamable)
-assignment = (,) <$> ((identifier <|> quoted) <* equal) <*> value
+assignment = ((,) <$> ((identifier <|> quoted) <* equal) <*> value) <* linebreaks
+
+linebreaks :: Parser ()
+linebreaks = void $ many newline
 
 value :: Parser TNamable
 value = choice
@@ -118,5 +124,8 @@ array = do elms <- p
            if not $ allSame elms
            then unexpected "Types do not match"
            else return $ TArray Inline elms
-    where p = between lbracket rbracket (try (endBy value comma) <|> sepBy value comma)
-
+    where p = between
+                (lbracket >> optional linebreaks)
+                (rbracket >> optional linebreaks)
+                (try (endBy value (comma <* optional linebreaks))
+                  <|> sepBy value (comma <* optional linebreaks))

--- a/src/Text/Toml/Tokenizer.hs
+++ b/src/Text/Toml/Tokenizer.hs
@@ -55,6 +55,7 @@ module Text.Toml.Tokenizer
            <|> true          pos
            <|> false         pos
            <|> identifier    pos
+           <|> newline       pos
 
    -- | A sequence of digits, interpreted as a decimal fraction  "123" => 0.123
    pfdecimal :: Parser Rational
@@ -281,6 +282,9 @@ module Text.Toml.Tokenizer
       cons w = (IdentifierT pos w, second (+ (fromIntegral $ T.length w)) pos)
       wordChar = inClass "-a-zA-Z0-9_"
 
+   -- | Parse a newline \"\n\".
+   newline :: Position -> Parser (Token, Position)
+   newline pos = char '\n' *> pret NewlineT pos
 
    -- | Like 'many', but retains the current source position
    manyWithPos :: (Position -> Parser ( a,  Position))
@@ -304,7 +308,6 @@ module Text.Toml.Tokenizer
       go line col =
          do c <- peekChar
             case c of
-               Just '\n' -> anyChar *> go (line+1) 1
                Just ' '  -> anyChar *> go line (col+1)
                Just '#'  -> anyChar *> takeWhile (/='\n') *> go line (col+1)
                Just '\t' -> anyChar *> go line (col+4)

--- a/src/Text/Toml/Types/Tokens.hs
+++ b/src/Text/Toml/Types/Tokens.hs
@@ -22,6 +22,7 @@ module Text.Toml.Types.Tokens(Token(..), tokenPos) where
       | FloatT         !(Int, Int) !Double !Text
       | DateT          !(Int, Int) !ZonedTime
       | LocalDateT     !(Int, Int) !LocalTime
+      | NewlineT       !(Int, Int)
      deriving (Eq, Show)
 
    instance Eq ZonedTime where
@@ -45,4 +46,5 @@ module Text.Toml.Types.Tokens(Token(..), tokenPos) where
       FloatT         pos _ _ -> pos
       DateT          pos _   -> pos
       LocalDateT     pos _   -> pos
+      NewlineT       pos     -> pos
 


### PR DESCRIPTION
- Preserve newlines across tokenization, so we can catch invalid documents with
  unexpected newlines at parse-time

  I'm not sure if this was the right way to solve this, or if there's a way to
  let *tokenization* itself fail on unexpected newlines -- but not have the
  parser ever need to know about them. Let me know what you think.

- Replace calls to `error` with monadic failure, so we get parse errors, not
  exceptions, on certain invalid documents.